### PR TITLE
Add heimdalljs monitoring

### DIFF
--- a/lib/metric.js
+++ b/lib/metric.js
@@ -1,0 +1,26 @@
+function Metric() {
+  this.count = 0;
+  this.time = 0;
+  this.startTime = undefined;
+}
+
+Metric.prototype.start = function() {
+  this.startTime = process.hrtime();
+  this.count++;
+};
+
+Metric.prototype.stop = function() {
+  var change = process.hrtime(this.startTime);
+
+  this.time += change[0] * 1e9 + change[1];
+  this.startTime = undefined;
+};
+
+Metric.prototype.toJSON = function() {
+  return {
+    count: this.count,
+    time: this.time
+  };
+};
+
+module.exports = Metric;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "debug": "^2.1.3",
+    "heimdalljs": "^0.2.3",
     "istextorbinary": "2.1.0",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.5.3",


### PR DESCRIPTION
Adds heimdalljs monitoring to the public interface of `Cache`so that stats are reported in heimdall nodes like so:

```
    {
      "_id": 486,
      "id": {
        "name": "applyPatches"
      },
      "stats": {
        "own": {},
        "time": {
          "self": 119480275
        },
        "async-disk-cache": {
          "get": {
            "count": 7,
            "time": 555904
          },
          "pathFor": {
            "count": 7,
            "time": 93636
          },
          "decompress": {
            "count": 7,
            "time": 1399261
          }
        }
      },
      "children": []
    },
```

cc @rwjblue @stefanpenner 