### PR TITLE
[Fixes #44] workaround username 2.0 not working with node 0.12

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ if (!heimdall.hasMonitor('async-disk-cache')) {
   heimdall.registerMonitor('async-disk-cache', function AsyncDiskCacheSchema() {});
 }
 
-var username = require('username').sync();
+var username = require('child_process').execSync('whoami').toString().trim();
 var tmpdir = path.join(os.tmpdir(), username);
 
 /*

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "istextorbinary": "2.1.0",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.5.3",
-    "rsvp": "^3.0.18",
-    "username": "^2.3.0"
+    "rsvp": "^3.0.18"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/test.js
+++ b/test.js
@@ -24,7 +24,7 @@ describe('cache', function() {
   it('has expected default root', function() {
     var os = require('os');
     var tmpdir = os.tmpdir();
-    var username = require('username').sync();
+    var username = require('child_process').execSync('whoami').toString().trim();
     var descriptiveName = 'if-you-need-to-delete-this-open-an-issue-async-disk-cache';
     var defaultKey = 'default-disk-cache';
 


### PR DESCRIPTION
NOTE: Please upgrade to a supported version of node: https://github.com/nodejs/LTS v0.12 is no longer covered by Node’s own Long-Term Support Working Group