### PR TITLE
[Fixes #56] use better username check (that is still compatible with …

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ if (!heimdall.hasMonitor('async-disk-cache')) {
   heimdall.registerMonitor('async-disk-cache', function AsyncDiskCacheSchema() {});
 }
 
-var username = require('child_process').execSync('whoami').toString().trim();
+var username = require('username-sync')();
 var tmpdir = path.join(os.tmpdir(), username);
 
 /*

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "mkdirp": "^0.5.0",
     "rimraf": "^2.5.3",
     "rsvp": "^3.0.18",
-    "username-sync": "^1.0.0"
+    "username-sync": "1.0.1"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "istextorbinary": "2.1.0",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.5.3",
-    "rsvp": "^3.0.18"
+    "rsvp": "^3.0.18",
+    "username-sync": "^1.0.0"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/test.js
+++ b/test.js
@@ -30,7 +30,7 @@ describe('cache', function() {
   it('has expected default root', function() {
     var os = require('os');
     var tmpdir = os.tmpdir();
-    var username = require('child_process').execSync('whoami').toString().trim();
+    var username = require('username-sync')();
     var descriptiveName = 'if-you-need-to-delete-this-open-an-issue-async-disk-cache';
     var defaultKey = 'default-disk-cache';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,9 +518,9 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
-username-sync@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/username-sync/-/username-sync-1.0.0.tgz#4d305662fb7d0bbc428f4d8698271eca8793888f"
+username-sync@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/username-sync/-/username-sync-1.0.1.tgz#1cde87eefcf94b8822984d938ba2b797426dae1f"
 
 which@^1.1.1:
   version "1.2.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -88,13 +88,6 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-cross-spawn-async@^2.1.1:
-  version "2.2.5"
-  resolved "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz#845ff0c0834a3ded9d160daca6d390906bb288cc"
-  dependencies:
-    lru-cache "^4.0.0"
-    which "^1.2.8"
-
 debug@2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
@@ -159,17 +152,6 @@ estraverse@^1.9.1:
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
-
-execa@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz#4eb6467a36a095fabb2970ff9d5e3fb7bce6ebc3"
-  dependencies:
-    cross-spawn-async "^2.1.1"
-    is-stream "^1.1.0"
-    npm-run-path "^1.0.0"
-    object-assign "^4.0.1"
-    path-key "^1.0.0"
-    strip-eof "^1.0.0"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -253,10 +235,6 @@ inherits@2:
 is-buffer@^1.0.2:
   version "1.1.4"
   resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz#cfc86ccd5dc5a52fa80489111c6920c457e2d98b"
-
-is-stream@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
 isexe@^1.1.1:
   version "1.1.2"
@@ -368,17 +346,6 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-lru-cache@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
-  dependencies:
-    pseudomap "^1.0.1"
-    yallist "^2.0.0"
-
-mem@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/mem/-/mem-0.1.1.tgz#24df988c3102b03c074c1b296239c5b2e6647825"
-
 "minimatch@2 || 3", minimatch@^3.0.2:
   version "3.0.3"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
@@ -425,16 +392,6 @@ nopt@3.x:
   dependencies:
     abbrev "1"
 
-npm-run-path@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz#f5c32bf595fe81ae927daec52e82f8b000ac3c8f"
-  dependencies:
-    path-key "^1.0.0"
-
-object-assign@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-
 once@1.x, once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -463,17 +420,9 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-key@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz#5d53d578019646c0d68800db4e146e6bdc2ac7af"
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
-
-pseudomap@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 repeat-string@^1.5.2:
   version "1.6.1"
@@ -527,10 +476,6 @@ stat-mode@^0.2.1:
   version "0.2.2"
   resolved "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz#e6c80b623123d7d80cf132ce538f346289072502"
 
-strip-eof@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
-
 supports-color@3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
@@ -573,14 +518,11 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
-username@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/username/-/username-2.3.0.tgz#ba37dd53ac7d6225e77730fdd79244f1fc058e1e"
-  dependencies:
-    execa "^0.4.0"
-    mem "^0.1.0"
+username-sync@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/username-sync/-/username-sync-1.0.0.tgz#4d305662fb7d0bbc428f4d8698271eca8793888f"
 
-which@^1.1.1, which@^1.2.8:
+which@^1.1.1:
   version "1.2.12"
   resolved "https://registry.npmjs.org/which/-/which-1.2.12.tgz#de67b5e450269f194909ef23ece4ebe416fa1192"
   dependencies:
@@ -605,10 +547,6 @@ wordwrap@~0.0.2:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-
-yallist@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz#306c543835f09ee1a4cb23b7bce9ab341c91cdd4"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
…node 0.12)

Anyone no-longer supporting node 0.12 should just use the username module